### PR TITLE
[Feat] point_logs, timers 테이블 생성

### DIFF
--- a/prisma/migrations/20260414053246_add_point_log/migration.sql
+++ b/prisma/migrations/20260414053246_add_point_log/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `srart_date` on the `habits` table. All the data in the column will be lost.
+  - Added the required column `start_date` to the `habits` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "habits" DROP COLUMN "srart_date",
+ADD COLUMN     "start_date" TIMESTAMP(3) NOT NULL;
+
+-- CreateTable
+CREATE TABLE "point_logs" (
+    "id" SERIAL NOT NULL,
+    "studyId" INTEGER NOT NULL,
+    "points" INTEGER NOT NULL DEFAULT 0,
+    "focus_duration" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "point_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "point_logs" ADD CONSTRAINT "point_logs_studyId_fkey" FOREIGN KEY ("studyId") REFERENCES "studies"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260414053832_add_timer/migration.sql
+++ b/prisma/migrations/20260414053832_add_timer/migration.sql
@@ -1,0 +1,22 @@
+-- CreateEnum
+CREATE TYPE "Status" AS ENUM ('IN_PROGRESS', 'PAUSED', 'CANCELED', 'COMPLETED');
+
+-- CreateTable
+CREATE TABLE "timers" (
+    "id" SERIAL NOT NULL,
+    "studyId" INTEGER NOT NULL,
+    "status" "Status" NOT NULL DEFAULT 'CANCELED',
+    "target_duration" INTEGER NOT NULL DEFAULT 1500000,
+    "elapsed_time" INTEGER NOT NULL DEFAULT 0,
+    "started_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "timers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "timers_studyId_key" ON "timers"("studyId");
+
+-- AddForeignKey
+ALTER TABLE "timers" ADD CONSTRAINT "timers_studyId_fkey" FOREIGN KEY ("studyId") REFERENCES "studies"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260414061134_update_point_log_timer_name/migration.sql
+++ b/prisma/migrations/20260414061134_update_point_log_timer_name/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `studyId` on the `point_logs` table. All the data in the column will be lost.
+  - You are about to drop the column `studyId` on the `timers` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[study_id]` on the table `timers` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `study_id` to the `point_logs` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `study_id` to the `timers` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "point_logs" DROP CONSTRAINT "point_logs_studyId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "timers" DROP CONSTRAINT "timers_studyId_fkey";
+
+-- DropIndex
+DROP INDEX "timers_studyId_key";
+
+-- AlterTable
+ALTER TABLE "point_logs" DROP COLUMN "studyId",
+ADD COLUMN     "study_id" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "timers" DROP COLUMN "studyId",
+ADD COLUMN     "study_id" INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "timers_study_id_key" ON "timers"("study_id");
+
+-- AddForeignKey
+ALTER TABLE "point_logs" ADD CONSTRAINT "point_logs_study_id_fkey" FOREIGN KEY ("study_id") REFERENCES "studies"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "timers" ADD CONSTRAINT "timers_study_id_fkey" FOREIGN KEY ("study_id") REFERENCES "studies"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260414061512_drop_point_log_timer/migration.sql
+++ b/prisma/migrations/20260414061512_drop_point_log_timer/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the `point_logs` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `timers` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "point_logs" DROP CONSTRAINT "point_logs_study_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "timers" DROP CONSTRAINT "timers_study_id_fkey";
+
+-- DropTable
+DROP TABLE "point_logs";
+
+-- DropTable
+DROP TABLE "timers";
+
+-- DropEnum
+DROP TYPE "Status";

--- a/prisma/migrations/20260414061735_add_point_log_timer/migration.sql
+++ b/prisma/migrations/20260414061735_add_point_log_timer/migration.sql
@@ -1,0 +1,37 @@
+-- CreateEnum
+CREATE TYPE "Status" AS ENUM ('IN_PROGRESS', 'PAUSED', 'CANCELED', 'COMPLETED');
+
+-- CreateTable
+CREATE TABLE "point_logs" (
+    "id" SERIAL NOT NULL,
+    "study_id" INTEGER NOT NULL,
+    "points" INTEGER NOT NULL DEFAULT 0,
+    "focus_duration" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "point_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "timers" (
+    "id" SERIAL NOT NULL,
+    "study_id" INTEGER NOT NULL,
+    "status" "Status" NOT NULL DEFAULT 'CANCELED',
+    "target_duration" INTEGER NOT NULL DEFAULT 1500000,
+    "elapsed_time" INTEGER NOT NULL DEFAULT 0,
+    "started_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "timers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "timers_study_id_key" ON "timers"("study_id");
+
+-- AddForeignKey
+ALTER TABLE "point_logs" ADD CONSTRAINT "point_logs_study_id_fkey" FOREIGN KEY ("study_id") REFERENCES "studies"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "timers" ADD CONSTRAINT "timers_study_id_fkey" FOREIGN KEY ("study_id") REFERENCES "studies"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,10 +17,10 @@ model Study {
   title     String
   description  String?
   background  String
+  habits    Habit[]
+  pointLogs PointLog[]
   createdAt DateTime @default(now())  @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
-
-  habits    Habit[]
 
   @@map("studies")
 }
@@ -30,7 +30,7 @@ model Habit {
   id        Int      @id @default(autoincrement())
   studyId   Int      @map("study_id")
   name      String
-  startDate DateTime @map("srart_date")
+  startDate DateTime @map("start_date")
   endDate   DateTime? @map("end_date")
   createdAt DateTime @default(now())  @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
@@ -54,4 +54,17 @@ model HabitRecord {
 
   @@unique([habitId, date])
   @@map("habit_records")
+}
+
+// PointLog 스키마
+model PointLog {
+  id        Int      @id @default(autoincrement())
+  studyId   Int
+  study     Study    @relation(fields: [studyId], references: [id], onDelete: Cascade)
+  points    Int      @default(0)
+  focusDuration Int  @map("focus_duration")
+  createdAt DateTime @default(now())  @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("point_logs")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Study {
   background  String
   habits    Habit[]
   pointLogs PointLog[]
+  timer     Timer?
   createdAt DateTime @default(now())  @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
@@ -67,4 +68,26 @@ model PointLog {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@map("point_logs")
+}
+
+// Timer 스키마
+enum Status {
+  IN_PROGRESS
+  PAUSED
+  CANCELED
+  COMPLETED
+}
+
+model Timer {
+  id        Int      @id @default(autoincrement())
+  studyId   Int      @unique
+  study     Study    @relation(fields: [studyId], references: [id], onDelete: Cascade)
+  status    Status   @default(CANCELED)
+  targetDuration Int @default(1500000) @map("target_duration")
+  elapsedTime Int    @default(0) @map("elapsed_time")
+  startedAt DateTime @default(now()) @map("started_at")
+  createdAt DateTime @default(now())  @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("timers")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,7 +60,7 @@ model HabitRecord {
 // PointLog 스키마
 model PointLog {
   id        Int      @id @default(autoincrement())
-  studyId   Int
+  studyId   Int      @map("study_id")
   study     Study    @relation(fields: [studyId], references: [id], onDelete: Cascade)
   points    Int      @default(0)
   focusDuration Int  @map("focus_duration")
@@ -80,7 +80,7 @@ enum Status {
 
 model Timer {
   id        Int      @id @default(autoincrement())
-  studyId   Int      @unique
+  studyId   Int      @unique @map("study_id")
   study     Study    @relation(fields: [studyId], references: [id], onDelete: Cascade)
   status    Status   @default(CANCELED)
   targetDuration Int @default(1500000) @map("target_duration")


### PR DESCRIPTION
## 🔥 Related Issues

- close #7 

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

DB에 획득 포인트를 저장하는 point_logs테이블과 타이머를 제어할 수 있는 timers테이블을 생성합니다.

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.
- PointLog 스키마 추가
- Timer 스키마 추가
- habit 컬럼명 오타 수정

## 📷 스크린샷

1. point_logs 테이블
<img width="925" height="163" alt="point_logs_테이블" src="https://github.com/user-attachments/assets/a9281749-c615-48d6-965c-8e764fc1ab64" />

2. timers 테이블
<img width="913" height="196" alt="timers_테이블" src="https://github.com/user-attachments/assets/71eb33e6-799f-4d0f-9825-1fbc7e33d031" />
