### PR TITLE
[Feat] 오늘의 습관 조회 API 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1340,7 +1340,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"

--- a/src/controllers/HabitController.js
+++ b/src/controllers/HabitController.js
@@ -48,16 +48,9 @@ export const getTodayHabits = async (req, res) => {
       },
     });
 
-    console.log('todayStart:', todayStart);
-    console.log('tomorrowStart:', tomorrowStart);
-    console.log('habitIds:', habitIds);
-    console.log('habitRecords:', habitRecords);
-
     const completedSet = new Set(
       habitRecords.filter((r) => r.isCompleted).map((r) => r.habitId),
     );
-
-    console.log('completedSet:', completedSet);
 
     const result = habits.map((h) => {
       return {

--- a/src/controllers/HabitController.js
+++ b/src/controllers/HabitController.js
@@ -1,0 +1,82 @@
+import prisma from '../lib/prisma.js';
+
+export const getTodayHabits = async (req, res) => {
+  try {
+    const { studyId } = req.params;
+
+    const study = await prisma.study.findUnique({
+      where: {
+        id: Number(studyId),
+      },
+    });
+
+    if (!study) {
+      return res.status(404).json({
+        success: false,
+        message: '스터디를 찾을 수 없습니다.',
+        errors: [],
+      });
+    }
+
+    const habits = await prisma.habit.findMany({
+      where: {
+        studyId: Number(studyId),
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+
+    const tomorrowStart = new Date(todayStart);
+    tomorrowStart.setDate(tomorrowStart.getDate() + 1);
+
+    const habitIds = habits.map((h) => h.id);
+
+    const habitRecords = await prisma.habitRecord.findMany({
+      where: {
+        habitId: {
+          in: habitIds,
+        },
+        date: {
+          gte: todayStart,
+          lt: tomorrowStart,
+        },
+      },
+    });
+
+    console.log('todayStart:', todayStart);
+    console.log('tomorrowStart:', tomorrowStart);
+    console.log('habitIds:', habitIds);
+    console.log('habitRecords:', habitRecords);
+
+    const completedSet = new Set(
+      habitRecords.filter((r) => r.isCompleted).map((r) => r.habitId),
+    );
+
+    console.log('completedSet:', completedSet);
+
+    const result = habits.map((h) => {
+      return {
+        id: h.id,
+        name: h.name,
+        isCompleted: completedSet.has(h.id),
+      };
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: '오늘의 습관 목록 조회에 성공했습니다.',
+      data: result,
+    });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: '서버 내부 오류가 발생했습니다.',
+      errores: [],
+    });
+  }
+};

--- a/src/routes/HabitRoutes.js
+++ b/src/routes/HabitRoutes.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { getTodayHabits } from '../controllers/HabitController.js';
+
+const router = express.Router({ mergeParams: true });
+
+router.get('/today', getTodayHabits);
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 import cors from 'cors';
 
 import pointsRoutes from './routes/pointsRoutes.js';
+import HabitRoutes from './routes/HabitRoutes.js';
 
 dotenv.config();
 
@@ -13,6 +14,8 @@ app.use(express.json());
 app.use(cors());
 
 app.use('/api/points', pointsRoutes);
+
+app.use('/api/studies/:studyId/habits', HabitRoutes);
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);


### PR DESCRIPTION
## 🔥 Related Issues

- close #6 

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.
오늘 기준 습관 목록을 조회하는 API를 구현했습니다.

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- GET /api/studies/:studyId/habits/today 라우트 구현
- study 존재 여부 검증 (없을 경우 404 처리)
- habits 목록 조회 (studyId 기준)
- 오늘 날짜 범위 계산 (00:00 ~ 다음날 00:00 미만)
- habit_records 조회 (today 기준)
- isCompleted 값 매핑 로직 구현
- 응답 형태 구성 (id, name, isCompleted)
- 빈 배열 및 예외 처리 구현

## 📷 스크린샷 (선택사항)

> 필요한 경우, 스크린샷을 남겨주세요.

- habitSeedData

<img width="1038" height="174" alt="image" src="https://github.com/user-attachments/assets/d6a20a7e-d3de-43ee-91b9-d14b3c50f136" />

- habitRecordSeedData

<img width="953" height="122" alt="image" src="https://github.com/user-attachments/assets/ebb6213f-efb2-4464-a987-055ebdf5740e" />

- 포스트맨 결과

<img width="780" height="509" alt="image" src="https://github.com/user-attachments/assets/44d19abf-a05a-4333-b0ca-37ca8a5d4a37" />

## 📦 참고사항 (선택사항)

- habit_records.date는 “기록 시각”이 아닌 “기록 날짜”로 사용합니다.
- today 조회 필터 정확도를 위해 토글 API에서 date를 00:00 기준으로 저장하도록 처리 예정입니다.
- 현재 조회 API는 todayStart ~ tomorrowStart 기준으로 동작합니다.