### PR TITLE
[feat] 검색/ 정렬/ 페이지네이션 api 구현

### DIFF
--- a/src/controllers/studyController.js
+++ b/src/controllers/studyController.js
@@ -16,12 +16,14 @@ export const getStudies = async (req, res) => {
 
     res.status(200).json({
       success: true,
+      message: '요청이 정상적으로 처리되었습니다.',
       data: studies,
     });
   } catch (error) {
-    res.status(400).json({
+    res.status(500).json({
       success: false,
-      message: error.message,
+      message: '서버 내부 오류가 발생했습니다.',
+      errors: [error.message],
     });
   }
 };

--- a/src/controllers/studyController.js
+++ b/src/controllers/studyController.js
@@ -1,8 +1,63 @@
 import prisma from '../lib/prisma.js';
 
+// 디폴트 값 설정
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 6;
+
+//정렬 허용 값
+const ALLOWED_ORDER_BY = ['latest', 'oldest', 'mostPoints', 'leastPoints'];
+
 export const getStudies = async (req, res) => {
   try {
+    const {
+      keyword = '',
+      orderBy = 'latest',
+      page = DEFAULT_PAGE,
+      pageSize = DEFAULT_PAGE_SIZE,
+    } = req.query;
+
+    const parsedPage = Number(page);
+    const parsedPageSize = Number(pageSize);
+
+    ////////////////// 400오류 //////////////////
+    if (
+      Number.isNaN(parsedPage) ||
+      parsedPage < 1 ||
+      Number.isNaN(parsedPageSize) ||
+      parsedPageSize < 1
+    ) {
+      return res.status(400).json({
+        success: false,
+        message: '잘못된 요청입니다.',
+        errors: ['page와 pageSize는 1 이상의 숫자여야 합니다.'],
+      });
+    }
+
+    if (!ALLOWED_ORDER_BY.includes(orderBy)) {
+      return res.status(400).json({
+        success: false,
+        message: '잘못된 요청입니다.',
+        errors: [
+          'orderBy는 latest, oldest, mostPoints, leastPoints 중 하나여야 합니다.',
+        ],
+      });
+    }
+
+    ////////////////// 검색 //////////////////
+    //mode: 'insensitive' 대소문자 구분 하지 않음
+    //키워드 있으면 타이틀이나 닉네임에서 검색, 없으면 전체 반환
+    const where = keyword
+      ? {
+          OR: [
+            { title: { contains: keyword, mode: 'insensitive' } },
+            { nickname: { contains: keyword, mode: 'insensitive' } },
+          ],
+        }
+      : {};
+
+    //프론트 보낼 데이터 select (password 포함하지 않았음. 추후에 수정 필요하면 변경하겠음)
     const studies = await prisma.study.findMany({
+      where,
       select: {
         id: true,
         nickname: true,
@@ -14,13 +69,104 @@ export const getStudies = async (req, res) => {
       },
     });
 
-    res.status(200).json({
+    ////////////////// 포인트 정렬 //////////////////
+    const studyIds = studies.map((study) => study.id);
+
+    /* const pointSums = [
+      { studyId: 10, _sum: { points: 25 } },
+      { studyId: 15, _sum: { points: 10 } }
+    ]; */
+    const pointSums =
+      studyIds.length > 0
+        ? await prisma.pointLog.groupBy({
+            by: ['studyId'],
+            where: {
+              studyId: {
+                in: studyIds, // 현재 조회된 스터디 id에 해당하는 pointLog만 가져옴
+              },
+            },
+            _sum: {
+              points: true, // 그룹별 포인트 합계 계산
+            },
+          })
+        : [];
+
+    /* 위에 pointSums를 그대로 두면 포인트를 찾을 때마다
+    pointSums.find((item) => item.studyId === study.id)과정이 필요함
+    [
+      [10, 25],
+      [15, 10]
+    ]*/
+    const pointMap = new Map(
+      pointSums.map((item) => [item.studyId, item._sum.points ?? 0]),
+    );
+
+    //스터디+총 포인트 새로운 배열 만듦
+    const studiesWithPoints = studies.map((study) => ({
+      ...study,
+      totalPoint: pointMap.get(study.id) ?? 0,
+    }));
+
+    const sortedStudies = [...studiesWithPoints].sort((a, b) => {
+      //오래된 순
+      if (orderBy === 'oldest') {
+        return new Date(a.createdAt) - new Date(b.createdAt);
+      }
+
+      //포인트 많은 순
+      if (orderBy === 'mostPoints') {
+        if (b.totalPoint !== a.totalPoint) {
+          return b.totalPoint - a.totalPoint;
+        }
+
+        return new Date(b.createdAt) - new Date(a.createdAt);
+      }
+
+      //포인트 적은 순
+      if (orderBy === 'leastPoints') {
+        if (a.totalPoint !== b.totalPoint) {
+          return a.totalPoint - b.totalPoint;
+        }
+
+        return new Date(b.createdAt) - new Date(a.createdAt);
+      }
+
+      //최근 순
+      return new Date(b.createdAt) - new Date(a.createdAt);
+    });
+
+    ////////////////// 페이지네이션 //////////////////
+    /*
+        totalCount : 정렬까지 끝난 전체 스터디 개수
+        totalPages : 전체개수 / pagesize
+        skip : 현재 페이지에서 앞쪽 몇 개 건너뛸지 계산
+        paginatedStudies : 해당 구간만 잘라내기
+    */
+    const totalCount = sortedStudies.length;
+    const totalPages = Math.ceil(totalCount / parsedPageSize);
+    const skip = (parsedPage - 1) * parsedPageSize;
+    const paginatedStudies = sortedStudies.slice(skip, skip + parsedPageSize);
+
+    ////////////////// 응답 //////////////////
+    return res.status(200).json({
       success: true,
       message: '요청이 정상적으로 처리되었습니다.',
-      data: studies,
+      data: {
+        studies: paginatedStudies,
+        pagination: {
+          currentPage: parsedPage,
+          pageSize: parsedPageSize,
+          totalCount,
+          totalPages,
+        },
+        filters: {
+          keyword,
+          orderBy,
+        },
+      },
     });
   } catch (error) {
-    res.status(500).json({
+    return res.status(500).json({
       success: false,
       message: '서버 내부 오류가 발생했습니다.',
       errors: [error.message],


### PR DESCRIPTION
## 📋 PR 기본 정보

- **프로젝트**: 초급 
- **주차**: 11주차
- **PR 요약**: 검색/정렬/페이지네이션 api 구현

---

## 🛠️ 구현 내용

> 이번 PR에서 구현하거나 수정한 내용을 간략히 설명해 주세요.

- 타이틀/ 닉네임에 키워드 포함되어 있으면 리스트 출력 (엔터 치면 검색됩니다)
- 최근 순, 오래된 순, 포인트 많은 순, 포인트 적은 순에 따라 정렬
- 한 페이지당 6개의 카드만 보여줄 수 있도록 페이지네이션 구성

---

## 🔍 코드리뷰 요청 사항

> **코드리뷰 멘토에게 피드백 받고 싶은 부분을 구체적으로 작성해 주세요.**
> 파일명, 라인 번호, 함수명 등을 함께 적어주시면 멘토가 집중해서 볼 수 있습니다.

### 요청 1

- **파일/위치**: 파일 하나라서 따로 말씀 안 드리겠습니다!

- **요청 내용**: 
  > 검색/정렬/페이지네이션 코드 제가 작성한 방식이 맞는 지, 효율적인건지 궁금합니다.

- **고민한 점**:
검색, 정렬, 페이지네이션을 구현할 때 처음에는 전체 데이터를 프론트엔드로 가져온 뒤 클라이언트에서 조건별로 처리할지 고민했습니다. 근데 클라이언트에서 처리하게 된다면 목록 데이터는 개수가 늘어날수록 렌더링 비용과 불필요한 데이터 전송이 커질 수 있다고 판단해서, 지금은 서버에서 쿼리 파라미터를 기준으로 검색, 정렬, 페이지네이션을 처리하고 필요한 데이터만 내려주는 방식으로 구현했습니다.
이 방식이 제가 생각한 방향으로는 더 효율적이라고 느꼈는데, 실제로도 서버에서 처리하는 방식이 일반적인지 궁금하고 페이지네이션처럼 여기저기서 자주 쓰이는 기능은 보통 직접 구현하는 편인지, 라이브러리를 사용하는 편인지도 궁금합니다. 그리고 만약 사용하신다면 라이브러리를 도입한 뒤 프로젝트 상황에 맞게 커스텀해서 사용하는지도 함께 여쭤보고 싶습니다!!
그리고 추가로, 코드 확장성 부분도 피드백 남겨주셨음 좋겠습니다! 사실 아직 어떤 부분이 부족한지도 잘 모르곘어서 어떻게 여쭤봐야 할 지 모르겠네요...ㅠㅠ

---
<img width="1462" height="997" alt="image" src="https://github.com/user-attachments/assets/f79e79ba-63b3-4f26-90b1-a87af3aefa1e" />