### PR TITLE
[Feat] Log 조회 API  구현

### DIFF
--- a/src/controllers/LogsController.js
+++ b/src/controllers/LogsController.js
@@ -1,0 +1,96 @@
+import prisma from '../lib/prisma.js'
+
+const getDateRange = (date) => {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+
+  const end = new Date(date);
+  end.setHours(23, 59, 59, 999);
+
+  return {start, end};
+}
+
+export const getPointLogs = async (req, res) => {
+  try {
+    const { studyId } = req.params;
+    const { date } = req.query;
+
+    const study = await prisma.study.findUnique({
+      where: { id: Number(studyId)},
+    })
+
+    const { start, end } = getDateRange(date);
+
+    const logs = await prisma.pointLog.findMany({
+      where: {
+        studyId: Number(studyId),
+        createdAt: {
+          // 하루치 데이터만 가져오기 위해 00:00 이상, 23:59 이하만
+          // >= 이상
+          gte: start,
+          // <== 이하
+          lte: end,
+        }
+      },
+
+      orderBy: {
+        createdAt: "asc",
+      }
+    })
+
+    return res.status(200).json({
+      "success": true,
+      "data": logs,
+      "message": "요청이 정상적으로 처리되었습니다.",
+    })
+  } catch (error) {
+    console.error(error);
+
+    return res.status(500).json({
+      "success": false,
+      "message": "서버 내부 오류가 발생했습니다.",
+      "errors": []
+    })
+  }
+}
+
+export const getFocusLogs = async (req, res) => {
+  try {
+    const { studyId } = req.params;
+    const { date} = req.query;
+
+    const study = await prisma.study.findUnique({
+      where: { id: Number(studyId)}
+    });
+
+    const {start, end} = getDateRange(date);
+
+    const logs = await prisma.pointLog.findMany({
+      where: {
+        studyId: Number(studyId),
+        createdAt: {
+          gte: start,
+          lte: end,
+        }
+      },
+
+      orderBy: {
+        createdAt: "asc",
+      }
+    })
+
+    return res.status(200).json({
+      "success": true,
+      "data": logs ?? [],
+      "message": "요청이 정상적으로 처리되었습니다.",
+    })
+  } catch (error) {
+    console.error(error);
+    
+    return res.status(500).json({
+      "success": false,
+      "message": "서버 내부 오류가 발생했습니다.",
+      "errors": []
+    })
+  }
+}

--- a/src/routes/LogsRoutes.js
+++ b/src/routes/LogsRoutes.js
@@ -1,0 +1,12 @@
+import express from "express";
+import {
+  getPointLogs,
+  getFocusLogs,
+} from '../controllers/LogsController.js'
+
+const router = express.Router();
+
+router.get('/:studyId/pointLogs', getPointLogs)
+router.get('/:studyId/focusLogs', getFocusLogs)
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ import cors from 'cors';
 import pointsRoutes from './routes/pointsRoutes.js';
 import HabitRoutes from './routes/HabitRoutes.js';
 import EmojiRoutes from './routes/EmojiRoutes.js';
+import LogsRoutes from './routes/LogsRoutes.js';
 
 dotenv.config();
 
@@ -22,6 +23,9 @@ app.use('/api/studies/:studyId/habits', HabitRoutes);
 
 //emoji
 app.use('/api/emojis', EmojiRoutes);
+
+// log
+app.use('/api/logs', LogsRoutes);
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);


### PR DESCRIPTION
## 🔥 Related Issues

- close #29 

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

- 로그페이지에서 포인트와 집중시간 로그 조회 가능하도록 구현했습니다..
- 불러올 데이터가 아직 없습니다..

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 집중시간 로그와 포인트 로그 API 라우팅했습니다.
- 00:00~23:59 단위로 자를 수 있게 범위를 설정합니다.
- 해당 날짜의 하루치 로그 데이터를 가져옵니다. (집중 성공 로그, 획득 포인트 로그)


