### PR TITLE
[Feat] 오늘의 습관 조회 및 완료 토글 API 구현

### DIFF
--- a/src/controllers/HabitController.js
+++ b/src/controllers/HabitController.js
@@ -145,3 +145,9 @@ export const createHabit = async (req, res) => {
     });
   }
 };
+
+// 습관 토글
+export const toggleHabit = async (req, res) => {
+  try {
+  } catch (error) {}
+};

--- a/src/controllers/HabitController.js
+++ b/src/controllers/HabitController.js
@@ -203,12 +203,8 @@ export const toggleHabit = async (req, res) => {
       success: true,
       message: '습관 완료 상태가 변경되었습니다.',
       data: {
-        success: true,
-        message: '습관 완료 상태가 변경되었습니다.',
-        data: {
-          habitId: 22,
-          isCompleted: true,
-        },
+        habitId: 22,
+        isCompleted: true,
       },
     });
   } catch (error) {

--- a/src/controllers/HabitController.js
+++ b/src/controllers/HabitController.js
@@ -9,6 +9,9 @@ export const getTodayHabits = async (req, res) => {
       where: {
         id: Number(studyId),
       },
+      select: {
+        title: true,
+      },
     });
 
     if (!study) {
@@ -18,55 +21,51 @@ export const getTodayHabits = async (req, res) => {
         errors: [],
       });
     }
-
-    const habits = await prisma.habit.findMany({
-      where: {
-        studyId: Number(studyId),
-      },
-      select: {
-        id: true,
-        name: true,
-      },
-    });
-
+    // today 추후 toggleHbit 파트랑 뭉쳐서 빼버리기
     const todayStart = new Date();
     todayStart.setHours(0, 0, 0, 0);
 
     const tomorrowStart = new Date(todayStart);
     tomorrowStart.setDate(tomorrowStart.getDate() + 1);
 
-    const habitIds = habits.map((h) => h.id);
-
-    const habitRecords = await prisma.habitRecord.findMany({
+    const habits = await prisma.habit.findMany({
       where: {
-        habitId: {
-          in: habitIds,
+        studyId: Number(studyId),
+      },
+      include: {
+        records: {
+          where: {
+            date: {
+              gte: todayStart,
+              lt: tomorrowStart,
+            },
+          },
+          select: {
+            isCompleted: true,
+          },
         },
-        date: {
-          gte: todayStart,
-          lt: tomorrowStart,
-        },
+      },
+      orderBy: {
+        id: 'asc',
       },
     });
 
-    const completedSet = new Set(
-      habitRecords.filter((r) => r.isCompleted).map((r) => r.habitId),
-    );
-
-    const result = habits.map((h) => {
-      return {
-        id: h.id,
-        name: h.name,
-        isCompleted: completedSet.has(h.id),
-      };
-    });
+    const habitIds = habits.map((h) => ({
+      id: h.id,
+      name: h.name,
+      isCompleted: h.records[0]?.isCompleted ?? false,
+    }));
 
     return res.status(200).json({
       success: true,
       message: '오늘의 습관 목록 조회에 성공했습니다.',
-      data: result,
+      data: {
+        studyTitle: study.title,
+        habits: habitIds,
+      },
     });
   } catch (error) {
+    console.error(error);
     return res.status(500).json({
       success: false,
       message: '서버 내부 오류가 발생했습니다.',
@@ -149,5 +148,69 @@ export const createHabit = async (req, res) => {
 // 습관 토글
 export const toggleHabit = async (req, res) => {
   try {
-  } catch (error) {}
+    const { studyId, habitId } = req.params;
+    const { isCompleted } = req.body;
+
+    const habit = await prisma.habit.findFirst({
+      where: {
+        id: Number(habitId),
+        studyId: Number(studyId),
+      },
+    });
+
+    if (!habit) {
+      return res.status(404).json({
+        success: false,
+        message: '습관을 찾을 수 없습니다.',
+        errors: [],
+      });
+    }
+
+    // 추후 조회 API 내 today ~ 와 함께 빼기
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+
+    const tomorrowStart = new Date(todayStart);
+    tomorrowStart.setDate(tomorrowStart.getDate() + 1);
+
+    const record = await prisma.habitRecord.findFirst({
+      where: {
+        habitId: Number(habitId),
+        date: {
+          gte: todayStart,
+          lt: tomorrowStart,
+        },
+      },
+    });
+
+    if (record) {
+      await prisma.habitRecord.update({
+        where: { id: record.id },
+        data: {
+          isCompleted: !record.isCompleted,
+        },
+      });
+    } else {
+      await prisma.habitRecord.create({
+        data: {
+          habitId: Number(habitId),
+          date: todayStart,
+          isCompleted: true,
+        },
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      message: '습관 완료 상태가 변경되었습니다.',
+      data: {},
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({
+      success: false,
+      message: '서버 내부 오류가 발생했습니다.',
+      errors: [],
+    });
+  }
 };

--- a/src/controllers/HabitController.js
+++ b/src/controllers/HabitController.js
@@ -203,7 +203,7 @@ export const toggleHabit = async (req, res) => {
       success: true,
       message: '습관 완료 상태가 변경되었습니다.',
       data: {
-        habitId: 22,
+        habitId,
         isCompleted: true,
       },
     });

--- a/src/controllers/HabitController.js
+++ b/src/controllers/HabitController.js
@@ -21,7 +21,7 @@ export const getTodayHabits = async (req, res) => {
         errors: [],
       });
     }
-    // today 추후 toggleHbit 파트랑 뭉쳐서 빼버리기
+    // today 추후 toggleHabit 파트랑 뭉쳐서 빼버리기
     const todayStart = new Date();
     todayStart.setHours(0, 0, 0, 0);
 
@@ -149,7 +149,6 @@ export const createHabit = async (req, res) => {
 export const toggleHabit = async (req, res) => {
   try {
     const { studyId, habitId } = req.params;
-    const { isCompleted } = req.body;
 
     const habit = await prisma.habit.findFirst({
       where: {

--- a/src/controllers/HabitController.js
+++ b/src/controllers/HabitController.js
@@ -202,7 +202,14 @@ export const toggleHabit = async (req, res) => {
     return res.status(200).json({
       success: true,
       message: '습관 완료 상태가 변경되었습니다.',
-      data: {},
+      data: {
+        success: true,
+        message: '습관 완료 상태가 변경되었습니다.',
+        data: {
+          habitId: 22,
+          isCompleted: true,
+        },
+      },
     });
   } catch (error) {
     console.error(error);

--- a/src/controllers/HabitReadController.js
+++ b/src/controllers/HabitReadController.js
@@ -1,0 +1,72 @@
+import prisma from '../lib/prisma.js';
+import { getTodayRange } from '../lib/DateRange.js';
+
+// 습관 조회
+export const getTodayHabits = async (req, res) => {
+  try {
+    const { studyId } = req.params;
+
+    const { start: todayStart, end: tomorrowStart } = getTodayRange();
+
+    const study = await prisma.study.findUnique({
+      where: {
+        id: Number(studyId),
+      },
+      select: {
+        title: true,
+      },
+    });
+
+    if (!study) {
+      return res.status(404).json({
+        success: false,
+        message: '스터디를 찾을 수 없습니다.',
+        errors: [],
+      });
+    }
+
+    const habits = await prisma.habit.findMany({
+      where: {
+        studyId: Number(studyId),
+      },
+      include: {
+        records: {
+          where: {
+            date: {
+              gte: todayStart,
+              lt: tomorrowStart,
+            },
+          },
+          select: {
+            isCompleted: true,
+          },
+        },
+      },
+      orderBy: {
+        id: 'asc',
+      },
+    });
+
+    const habitIds = habits.map((h) => ({
+      id: h.id,
+      name: h.name,
+      isCompleted: h.records[0]?.isCompleted ?? false,
+    }));
+
+    return res.status(200).json({
+      success: true,
+      message: '오늘의 습관 목록 조회에 성공했습니다.',
+      data: {
+        studyTitle: study.title,
+        habits: habitIds,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({
+      success: false,
+      message: '서버 내부 오류가 발생했습니다.',
+      errors: [],
+    });
+  }
+};

--- a/src/controllers/HabitReadController.js
+++ b/src/controllers/HabitReadController.js
@@ -1,12 +1,12 @@
 import prisma from '../lib/prisma.js';
-import { getTodayRange } from '../lib/DateRange.js';
+import { getDateRange } from '../lib/DateRange.js';
 
 // 습관 조회
 export const getTodayHabits = async (req, res) => {
   try {
     const { studyId } = req.params;
 
-    const { start: todayStart, end: tomorrowStart } = getTodayRange();
+    const { start, end } = getDateRange(new Date());
 
     const study = await prisma.study.findUnique({
       where: {
@@ -33,8 +33,8 @@ export const getTodayHabits = async (req, res) => {
         records: {
           where: {
             date: {
-              gte: todayStart,
-              lt: tomorrowStart,
+              gte: start,
+              lte: end,
             },
           },
           select: {

--- a/src/controllers/HabitWriteController.js
+++ b/src/controllers/HabitWriteController.js
@@ -1,5 +1,5 @@
 import prisma from '../lib/prisma.js';
-import { getTodayRange } from '../lib/DateRange.js';
+import { getDateRange } from '../lib/DateRange.js';
 
 // 습관 생성
 export const createHabit = async (req, res) => {
@@ -77,7 +77,7 @@ export const toggleHabit = async (req, res) => {
   try {
     const { studyId, habitId } = req.params;
 
-    const { start: todayStart, end: tomorrowStart } = getTodayRange();
+    const { start, end } = getDateRange(new Date());
 
     const habit = await prisma.habit.findFirst({
       where: {
@@ -98,8 +98,8 @@ export const toggleHabit = async (req, res) => {
       where: {
         habitId: Number(habitId),
         date: {
-          gte: todayStart,
-          lt: tomorrowStart,
+          gte: start,
+          lte: end,
         },
       },
     });
@@ -117,7 +117,7 @@ export const toggleHabit = async (req, res) => {
       updatedRecord = await prisma.habitRecord.create({
         data: {
           habitId: Number(habitId),
-          date: todayStart,
+          date: start,
           isCompleted: true,
         },
       });

--- a/src/controllers/HabitWriteController.js
+++ b/src/controllers/HabitWriteController.js
@@ -1,78 +1,5 @@
 import prisma from '../lib/prisma.js';
-
-// 습관 조회
-export const getTodayHabits = async (req, res) => {
-  try {
-    const { studyId } = req.params;
-
-    const study = await prisma.study.findUnique({
-      where: {
-        id: Number(studyId),
-      },
-      select: {
-        title: true,
-      },
-    });
-
-    if (!study) {
-      return res.status(404).json({
-        success: false,
-        message: '스터디를 찾을 수 없습니다.',
-        errors: [],
-      });
-    }
-    // today 추후 toggleHabit 파트랑 뭉쳐서 빼버리기
-    const todayStart = new Date();
-    todayStart.setHours(0, 0, 0, 0);
-
-    const tomorrowStart = new Date(todayStart);
-    tomorrowStart.setDate(tomorrowStart.getDate() + 1);
-
-    const habits = await prisma.habit.findMany({
-      where: {
-        studyId: Number(studyId),
-      },
-      include: {
-        records: {
-          where: {
-            date: {
-              gte: todayStart,
-              lt: tomorrowStart,
-            },
-          },
-          select: {
-            isCompleted: true,
-          },
-        },
-      },
-      orderBy: {
-        id: 'asc',
-      },
-    });
-
-    const habitIds = habits.map((h) => ({
-      id: h.id,
-      name: h.name,
-      isCompleted: h.records[0]?.isCompleted ?? false,
-    }));
-
-    return res.status(200).json({
-      success: true,
-      message: '오늘의 습관 목록 조회에 성공했습니다.',
-      data: {
-        studyTitle: study.title,
-        habits: habitIds,
-      },
-    });
-  } catch (error) {
-    console.error(error);
-    return res.status(500).json({
-      success: false,
-      message: '서버 내부 오류가 발생했습니다.',
-      errors: [],
-    });
-  }
-};
+import { getTodayRange } from '../lib/DateRange.js';
 
 // 습관 생성
 export const createHabit = async (req, res) => {
@@ -150,6 +77,8 @@ export const toggleHabit = async (req, res) => {
   try {
     const { studyId, habitId } = req.params;
 
+    const { start: todayStart, end: tomorrowStart } = getTodayRange();
+
     const habit = await prisma.habit.findFirst({
       where: {
         id: Number(habitId),
@@ -165,13 +94,6 @@ export const toggleHabit = async (req, res) => {
       });
     }
 
-    // 추후 조회 API 내 today ~ 와 함께 빼기
-    const todayStart = new Date();
-    todayStart.setHours(0, 0, 0, 0);
-
-    const tomorrowStart = new Date(todayStart);
-    tomorrowStart.setDate(tomorrowStart.getDate() + 1);
-
     const record = await prisma.habitRecord.findFirst({
       where: {
         habitId: Number(habitId),
@@ -182,15 +104,17 @@ export const toggleHabit = async (req, res) => {
       },
     });
 
+    let updatedRecord;
+
     if (record) {
-      await prisma.habitRecord.update({
+      updatedRecord = await prisma.habitRecord.update({
         where: { id: record.id },
         data: {
           isCompleted: !record.isCompleted,
         },
       });
     } else {
-      await prisma.habitRecord.create({
+      updatedRecord = await prisma.habitRecord.create({
         data: {
           habitId: Number(habitId),
           date: todayStart,
@@ -203,8 +127,8 @@ export const toggleHabit = async (req, res) => {
       success: true,
       message: '습관 완료 상태가 변경되었습니다.',
       data: {
-        habitId,
-        isCompleted: true,
+        habitId: Number(habitId),
+        isCompleted: updatedRecord.isCompleted,
       },
     });
   } catch (error) {

--- a/src/lib/DateRange.js
+++ b/src/lib/DateRange.js
@@ -1,0 +1,9 @@
+export const getTodayRange = () => {
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+
+  const tomorrowStart = new Date(todayStart);
+  tomorrowStart.setDate(tomorrowStart.getDate() + 1);
+
+  return { start: todayStart, end: tomorrowStart };
+};

--- a/src/lib/DateRange.js
+++ b/src/lib/DateRange.js
@@ -1,9 +1,9 @@
-export const getTodayRange = () => {
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
+export const getDateRange = (date) => {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
 
-  const tomorrowStart = new Date(todayStart);
-  tomorrowStart.setDate(tomorrowStart.getDate() + 1);
+  const end = new Date(date);
+  end.setHours(23, 59, 59, 999);
 
-  return { start: todayStart, end: tomorrowStart };
+  return { start, end };
 };

--- a/src/routes/HabitRoutes.js
+++ b/src/routes/HabitRoutes.js
@@ -1,9 +1,9 @@
 import express from 'express';
 import {
-  getTodayHabits,
   createHabit,
   toggleHabit,
-} from '../controllers/HabitController.js';
+} from '../controllers/HabitWriteController.js';
+import { getTodayHabits } from '../controllers/HabitReadController.js';
 
 const router = express.Router();
 

--- a/src/routes/HabitRoutes.js
+++ b/src/routes/HabitRoutes.js
@@ -1,10 +1,14 @@
 import express from 'express';
-import { getTodayHabits, createHabit } from '../controllers/HabitController.js';
+import {
+  getTodayHabits,
+  createHabit,
+  toggleHabit,
+} from '../controllers/HabitController.js';
 
 const router = express.Router();
 
 router.get('/:studyId/today', getTodayHabits);
 router.post('/:studyId', createHabit);
-router.post('/:studyId/:habitId/today', toggleHabit);
+router.patch('/:studyId/:habitId/today', toggleHabit);
 
 export default router;

--- a/src/routes/HabitRoutes.js
+++ b/src/routes/HabitRoutes.js
@@ -5,5 +5,6 @@ const router = express.Router();
 
 router.get('/:studyId/today', getTodayHabits);
 router.post('/:studyId', createHabit);
+router.post('/:studyId/:habitId/today', toggleHabit);
 
 export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -21,6 +21,7 @@ app.use('/api/points', pointsRoutes);
 // study
 app.use('/api/studies', studyRoutes);
 
+// habit
 app.use('/api/habits', HabitRoutes);
 
 //emoji


### PR DESCRIPTION
## 📋 PR 기본 정보

- **프로젝트**: 초급
- **주차**: 11주차
- **PR 요약**: 오늘의 습관 조회/토글 기능 구현 및 컨트롤러 분리, 날짜 범위 유틸 분리

---

## 🛠️ 구현 내용

> 이번 PR에서 구현하거나 수정한 내용을 간략히 설명해 주세요.

* 오늘의 습관 조회 API를 read 컨트롤러로 분리했습니다.
* 습관 생성/토글 API를 write 컨트롤러로 분리했습니다.
* 날짜 범위 계산 로직을 DateRange 유틸로 분리했습니다.
* 토글 API 응답에 habitId, isCompleted를 포함하도록 수정했습니다.
* 오늘의 습관 조회 시 studyTitle과 habits를 함께 반환하도록 응답 구조를 변경했습니다.

---

## 🔍 코드리뷰 요청 사항

> **코드리뷰 멘토에게 피드백 받고 싶은 부분을 구체적으로 작성해 주세요.**
> 파일명, 라인 번호, 함수명 등을 함께 적어주시면 멘토가 집중해서 볼 수 있습니다.

### 요청 1
- **파일/위치**: `src/controllers/HabitWriteController.js`
- **요청 내용**:
> 현재는 habit record가 없으면 생성하고, 있으면 isCompleted 값을 true/false로 토글하는 방식으로 구현했습니다.
> 완료 상태만 record로 남기고, 미완료 시에는 record를 삭제하는 방식과 비교했을 때 현재 방식이 적절한지 피드백 받고 싶습니다.

- **고민한 점**:
> 초기 설계 시 사용자가 완료 처리 후 다시 미완료로 되돌릴 수 있는 흐름을 고려해, 상태를 토글 형태(true/false)로 관리하는 것이 자연스럽다고 판단했습니다.
그래서 record를 삭제하기보다는 isCompleted 값을 변경하는 방식으로 구현했습니다.
>
> 근데 강사님께서 완료 상태만 record로 관리하고, 미완료 시에는 record를 삭제하는 방식도 가능하다고 말씀해주셨습니다.
해당 방식은 유지보수 측면에서 더 단순해질 수 있고, 반대로 현재 방식은 상태를 명시적으로 관리하기 때문에 DB 연산 측면에서 장점이 있을 수 있다고 이해했습니다.
>
> 두 방식 모두 장단점이 있는 상황에서, 현재 프로젝트 규모와 이후 주간 조회/통계 기능 확장까지 고려했을 때 어떤 기준으로 선택하는 것이 적절할지 궁금합니다.

### 요청 2 (선택)
- **파일/위치**: `src/lib/DateRange.js`
- **요청 내용**:  
```
    const todayStart = new Date();
    todayStart.setHours(0, 0, 0, 0);

    const tomorrowStart = new Date(todayStart);
    tomorrowStart.setDate(tomorrowStart.getDate() + 1);
```
> 기존에는 위와 같이 todayStart ~ tomorrowStart 방식으로 하루 범위를 정의했으나, 공통 유틸로 분리하는 과정에서 타 팀원 코드(00:00:00 ~ 23:59:59.999) 방식으로 대체했습니다.
> 두 방식 모두 하루 범위를 표현하는 데 사용할 수 있는 것으로 알고 있는데, 현재 프로젝트에서 어떤 방식을 사용하는 것이 더 적절한지 피드백 받고 싶습니다.

- **고민한 점**:
> 두 방식 모두 하루 범위를 표현하는 데 사용할 수 있고, 코드상 정답은 없다고 생각합니다.
> 다만 실제 현업에서는 어떤 방식을 더 많이 사용하는지, 그리고 그 기준이 무엇인지 궁금합니다.
> 특히 이후 주간 조회나 통계 기능 확장까지 고려했을 때 어떤 방식이 더 적절한 선택인지 피드백 부탁드립니다.
---

## ⚠️ 특이사항 / 참고 사항

- 기존 HabitController.js에 있던 로직을 조회/쓰기 기준으로 분리했습니다.
- 날짜 범위 계산 로직은 DateRange 유틸로 옮겼습니다.
- 토글 API는 현재 record가 없으면 생성, 있으면 isCompleted 반전 방식으로 구현되어 있습니다.
- 본의 아니게 고민되던 부분이 내용이 많은 PR 안에 담겨 있네요 ...

---
---

-📒 설명

오늘의 습관 조회 응답 구조를 수정하고 완료 토글 API를 구현했습니다.

🛠️ 작업 내용
- 오늘의 습관 조회 응답에 studyTitle 추가
- 오늘 날짜 기준 habit record 조회 후 isCompleted 값 포함
- records relation 기준으로 조회 로직 수정
- 완료 토글 API 구현
- 오늘 record 존재 시 isCompleted 반전 처리
- 오늘 record 없을 경우 새 record 생성 처리
- 응답 메시지 및 일부 오타 수정

📷 스크린샷 (선택사항)

필요한 경우, 스크린샷을 남겨주세요.

<img width="671" height="365" alt="image" src="https://github.com/user-attachments/assets/6b2212d9-be7c-4212-84b4-bfc8f081e679" />

<img width="676" height="278" alt="image" src="https://github.com/user-attachments/assets/72cd381c-bbd0-4b6d-8a51-db3fd5d3924d" />

📦 참고사항 (선택사항)

ex: OOO 패키지를 적용했습니다! npm install ~~~ 

- 오늘의 습관 조회 응답 구조가 studyTitle, habits 형태로 변경되었습니다.
- 날짜 범위 계산 로직은 추후 공통 유틸로 분리 예정이었는데, 아예 조회 컨트롤러를 따로 뺄 지 고민중에 있습니다.