### PR TITLE
[Feat] 타이머 집중 목표 시간 설정, 시작, 일시정지, 리셋 API 구현

### DIFF
--- a/src/controllers/timerController.js
+++ b/src/controllers/timerController.js
@@ -50,6 +50,8 @@ export const getTimer = async (req, res) => {
         id: studyId,
       },
       select: {
+        title: true,
+        description: true,
         timer: true,
       },
     });
@@ -61,6 +63,8 @@ export const getTimer = async (req, res) => {
       success: true,
       message: '요청이 정상적으로 처리되었습니다.',
       data: {
+        title: study.title,
+        description: study.description,
         timer: study.timer,
       },
     });

--- a/src/controllers/timerController.js
+++ b/src/controllers/timerController.js
@@ -138,7 +138,7 @@ export const updateStart = async (req, res) => {
       },
       data: {
         status,
-        startedAt,
+        startedAt: new Date(startedAt),
       },
     });
 
@@ -177,7 +177,7 @@ export const updatePause = async (req, res) => {
 
     const now = Date.now();
 
-    const elapsedTime = now - timer.startedAt;
+    const elapsedTime = now - timer.startedAt + timer.elapsedTime;
 
     const updateStatus = await prisma.timer.update({
       where: {

--- a/src/controllers/timerController.js
+++ b/src/controllers/timerController.js
@@ -1,32 +1,70 @@
 import prisma from '../lib/prisma.js';
 
-export const upsertTimer = async (req, res) => {
+export const createTimer = async (req, res) => {
   try {
-    const studyId = Number(req.body.studyId);
+    const studyId = Number(req.params.studyId);
 
     const hasStudy = await prisma.study.findFirst({
       where: {
         id: studyId,
       },
+      select: {
+        id: true,
+        timer: true,
+      },
     });
-    if (!hasStudy) {
+    if (!hasStudy.id) {
       throw new Error('해당 스터디를 찾을 수 없습니다');
     }
 
     // 타이머가 없을 때만 생성
-    const timer = await prisma.timer.upsert({
+    if (!hasStudy.timer) {
+      const timer = await prisma.timer.create({
+        data: {
+          studyId,
+        },
+      });
+
+      return res.status(201).json({
+        success: true,
+        message: '타이머가 정상적으로 생성되었습니다.',
+        data: {
+          timer,
+        },
+      });
+    }
+
+    res.status(200).json({
+      success: true,
+      message: '이미 타이머가 생성되었습니다.',
+      data: {
+        timer: hasStudy.timer,
+      },
+    });
+  } catch (error) {
+    res.status(400).json({
+      success: false,
+      message: error.message,
+    });
+  }
+};
+
+export const getTimer = async (req, res) => {
+  try {
+    const studyId = Number(req.params.studyId);
+
+    const timer = await prisma.timer.findFirst({
       where: {
         studyId,
       },
-      update: {},
-      create: {
-        studyId,
-      },
     });
+    if (!timer) {
+      throw new Error('해당 타이머를 찾을 수 없습니다');
+    }
 
-    res.status(201).json({
+    res.status(200).json({
       success: true,
-      message: '타이머가 정상적으로 생성되었습니다.',
+      message: '요청이 정상적으로 처리되었습니다.',
       data: {
         timer,
       },

--- a/src/controllers/timerController.js
+++ b/src/controllers/timerController.js
@@ -51,7 +51,6 @@ export const getTimer = async (req, res) => {
       },
       select: {
         title: true,
-        description: true,
         timer: true,
       },
     });
@@ -64,7 +63,6 @@ export const getTimer = async (req, res) => {
       message: '요청이 정상적으로 처리되었습니다.',
       data: {
         title: study.title,
-        description: study.description,
         timer: study.timer,
       },
     });

--- a/src/controllers/timerController.js
+++ b/src/controllers/timerController.js
@@ -9,36 +9,28 @@ export const createTimer = async (req, res) => {
         id: studyId,
       },
       select: {
-        id: true,
         timer: true,
       },
     });
-    if (!hasStudy.id) {
+    if (!hasStudy) {
       throw new Error('해당 스터디를 찾을 수 없습니다');
     }
-
     // 타이머가 없을 때만 생성
-    if (!hasStudy.timer) {
-      const timer = await prisma.timer.create({
-        data: {
-          studyId,
-        },
-      });
-
-      return res.status(201).json({
-        success: true,
-        message: '타이머가 정상적으로 생성되었습니다.',
-        data: {
-          timer,
-        },
-      });
+    if (hasStudy.timer) {
+      throw new Error('이미 타이머가 생성되었습니다.');
     }
 
-    res.status(200).json({
-      success: true,
-      message: '이미 타이머가 생성되었습니다.',
+    const timer = await prisma.timer.create({
       data: {
-        timer: hasStudy.timer,
+        studyId,
+      },
+    });
+
+    res.status(201).json({
+      success: true,
+      message: '타이머가 정상적으로 생성되었습니다.',
+      data: {
+        timer,
       },
     });
   } catch (error) {
@@ -53,20 +45,23 @@ export const getTimer = async (req, res) => {
   try {
     const studyId = Number(req.params.studyId);
 
-    const timer = await prisma.timer.findFirst({
+    const study = await prisma.study.findFirst({
       where: {
-        studyId,
+        id: studyId,
+      },
+      select: {
+        timer: true,
       },
     });
-    if (!timer) {
-      throw new Error('해당 타이머를 찾을 수 없습니다');
+    if (!study) {
+      throw new Error('해당 스터디를 찾을 수 없습니다');
     }
 
     res.status(200).json({
       success: true,
       message: '요청이 정상적으로 처리되었습니다.',
       data: {
-        timer,
+        timer: study.timer,
       },
     });
   } catch (error) {

--- a/src/controllers/timerController.js
+++ b/src/controllers/timerController.js
@@ -38,3 +38,177 @@ export const upsertTimer = async (req, res) => {
     });
   }
 };
+
+export const updateTargetDuraion = async (req, res) => {
+  try {
+    const studyId = Number(req.params.studyId);
+    const targetDuration = Number(req.body.targetDuration);
+
+    const timer = await prisma.timer.findFirst({
+      where: {
+        studyId,
+      },
+    });
+    if (!timer) {
+      throw new Error('해당 타이머를 찾을 수 없습니다');
+    }
+    if (timer.status === 'IN_PROGRESS') {
+      throw new Error('타이머 진행중엔 수정이 불가능합니다.');
+    }
+
+    const updatedTargetDuration = await prisma.timer.update({
+      where: {
+        studyId,
+      },
+      data: {
+        targetDuration,
+      },
+    });
+
+    res.status(200).json({
+      success: true,
+      message: '목표시간이 정상적으로 업데이트 되었습니다.',
+      data: {
+        updatedTargetDuration,
+      },
+    });
+  } catch (error) {
+    res.status(400).json({
+      success: false,
+      message: error.message,
+    });
+  }
+};
+
+export const updateStart = async (req, res) => {
+  try {
+    const studyId = Number(req.params.studyId);
+    const status = 'IN_PROGRESS';
+
+    const timer = await prisma.timer.findFirst({
+      where: {
+        studyId,
+      },
+    });
+    if (!timer) {
+      throw new Error('해당 타이머를 찾을 수 없습니다');
+    }
+    if (timer.status === 'IN_PROGRESS') {
+      throw new Error('이미 타이머가 진행중입니다.');
+    }
+
+    const startedAt = Date.now();
+
+    const updateStatus = await prisma.timer.update({
+      where: {
+        studyId,
+      },
+      data: {
+        status,
+        startedAt,
+      },
+    });
+
+    res.status(200).json({
+      success: true,
+      message: '타이머 상태가 정상적으로 업데이트 되었습니다.',
+      data: {
+        updateStatus,
+      },
+    });
+  } catch (error) {
+    res.status(400).json({
+      success: false,
+      message: error.message,
+    });
+  }
+};
+
+export const updatePause = async (req, res) => {
+  try {
+    const studyId = Number(req.params.studyId);
+    const status = 'PAUSED';
+
+    const timer = await prisma.timer.findFirst({
+      where: {
+        studyId,
+      },
+    });
+    if (!timer) {
+      throw new Error('해당 타이머를 찾을 수 없습니다');
+    }
+
+    if (timer.status === 'CANCELED' || timer.status === 'PAUSED') {
+      throw new Error('타이머가 진행중이지 않습니다.');
+    }
+
+    const now = Date.now();
+
+    const elapsedTime = now - timer.startedAt;
+
+    const updateStatus = await prisma.timer.update({
+      where: {
+        studyId,
+      },
+      data: {
+        status,
+        elapsedTime,
+      },
+    });
+
+    res.status(200).json({
+      success: true,
+      message: '타이머 상태가 정상적으로 업데이트 되었습니다.',
+      data: {
+        updateStatus,
+      },
+    });
+  } catch (error) {
+    res.status(400).json({
+      success: false,
+      message: error.message,
+    });
+  }
+};
+
+export const updateReset = async (req, res) => {
+  try {
+    const studyId = Number(req.params.studyId);
+    const status = 'CANCELED';
+
+    const timer = await prisma.timer.findFirst({
+      where: {
+        studyId,
+      },
+    });
+    if (!timer) {
+      throw new Error('해당 타이머를 찾을 수 없습니다');
+    }
+    if (timer.status === 'CANCELED') {
+      throw new Error('타이머가 진행중이지 않습니다.');
+    }
+
+    const updateStatus = await prisma.timer.update({
+      where: {
+        studyId,
+      },
+      data: {
+        status,
+        elapsedTime: 0,
+      },
+    });
+
+    res.status(200).json({
+      success: true,
+      message: '타이머 상태가 정상적으로 업데이트 되었습니다.',
+      data: {
+        updateStatus,
+      },
+    });
+  } catch (error) {
+    res.status(400).json({
+      success: false,
+      message: error.message,
+    });
+  }
+};

--- a/src/routes/timerRoutes.js
+++ b/src/routes/timerRoutes.js
@@ -1,15 +1,18 @@
 import express from 'express';
 import {
+  createTimer,
+  getTimer,
   updatePause,
   updateReset,
   updateStart,
   updateTargetDuraion,
-  upsertTimer,
 } from '../controllers/timerController.js';
 
 const router = express.Router();
 
-router.post('/', upsertTimer);
+router.post('/:studyId', createTimer);
+
+router.get('/:studyId', getTimer);
 
 router.patch('/:studyId/target-duration', updateTargetDuraion);
 

--- a/src/routes/timerRoutes.js
+++ b/src/routes/timerRoutes.js
@@ -1,8 +1,22 @@
 import express from 'express';
-import { upsertTimer } from '../controllers/timerController.js';
+import {
+  updatePause,
+  updateReset,
+  updateStart,
+  updateTargetDuraion,
+  upsertTimer,
+} from '../controllers/timerController.js';
 
 const router = express.Router();
 
 router.post('/', upsertTimer);
+
+router.patch('/:studyId/target-duration', updateTargetDuraion);
+
+router.patch('/:studyId/start', updateStart);
+
+router.patch('/:studyId/pause', updatePause);
+
+router.patch('/:studyId/reset', updateReset);
 
 export default router;


### PR DESCRIPTION
## 🔥 Related Issues

- close #27 

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

기존에 구현했던 upsertTimer를 생성과 조회 함수로 분리
타이머의 집중 목표 시간과 시작, 일시정지, 리셋 상태를 변경하고 DB에 저장하는 API를 구현

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 타이머 생성, 타이머 조회 API를 분리
- 타이머 집중 목표 시간을 DB에 저장하고 타이머의 상태를 변경해주는 API 구현
- 타이머 마지막 시작 시간을 DB에 저장하고 타이머의 상태를 변경해주는 API 구현
- 타이머 실제 경과 시간을 DB에 저장하고 타이머의 상태를 변경해주는 API 구현
- 타이머 실제 경과 시간를 초기화한 값을 DB에 저장하고 타이머의 상태를 변경해주는 API 구현
