### PR TITLE
[Feat] 습관 수정 및 삭제(종료) API 구현

### DIFF
--- a/src/controllers/HabitWriteController.js
+++ b/src/controllers/HabitWriteController.js
@@ -144,42 +144,32 @@ export const toggleHabit = async (req, res) => {
 // 습관 수정
 export const editHabit = async (req, res) => {
     try {
-      const { studyId, habitId} = req.params;
+      const { studyId, habitId } = req.params;
       const { name } = req.body;
 
-      if (!name || name.trim() === "") {
-        return res.status(400).json({
-          success: false,
-          massage: '잘못된 요청입니다.',
-          errors: '이름은 필수 입력값입니다.',
-        });
-      }
+      // if (!name || name.trim() === "") {
+      //   return res.status(400).json({
+      //     success: false,
+      //     massage: '잘못된 요청입니다.',
+      //     errors: '습관 이름은 필수 입력값입니다.',
+      //   });
+      // }
 
-      const habit = await prisma.habit.findFirst({
-        where: {
-          id: Number(habitId),
-          studyId: Number(studyId),
-          endDate: null,
+      const updatedHabit = await prisma.habit.update({
+        where: { 
+          id: Number(habitId), 
+        },
+        data: { 
+          name: name.trim(),
         },
       });
-
-      if (!habit) {
-        return res.status(404).json({
-          success: false,
-          message: '수정할 습관을 찾을 수 없습니다.',
-          errors: [],
-        });
-      }
-
-      const updateHabit = await prisma.habit.update({
-        where: { id: Number(habitId) },
-        data: { name: name.trim()},
-      })
 
       return res.status(200).json({
         success:true,
         message: '습관이 수정되었습니다.',
-        data: { habit: updateHabit }
+        data: { 
+          habit: updatedHabit 
+        }
       });
 
     } catch (error) {
@@ -192,10 +182,48 @@ export const editHabit = async (req, res) => {
   }
 };
 
+// 습관 삭제
 export const deleteHabit = async (req, res) => {
   try {
+    const { habitId } = req.params;
 
-  } catch (error) {
+    const habit = await prisma.habit.findFirst({
+      where: {
+        id: Number(habitId),
+      }
+    })
 
+    if (!habit) {
+      return res.status(404).json({
+        success: false,
+        message: '종료할 습관을 찾을 수 없습니다.',
+        errors: [],
+      });
+    }
+
+    const endedHabit = await prisma.habit.update({
+      where: { 
+        id: Number(habitId)
+      },
+      data: { 
+        endDate: new Date() 
+      },
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: '습관이 삭제되었습니다.',
+      data: { 
+        habit: endedHabit 
+      }
+    });
+
+    } catch (error) {
+    console.error(error);
+    return res.status(500).json({
+      success: false,
+      message: '서버 내부 오류가 발생했습니다.',
+      errors: [],
+    });
   }
 };

--- a/src/controllers/HabitWriteController.js
+++ b/src/controllers/HabitWriteController.js
@@ -147,13 +147,13 @@ export const editHabit = async (req, res) => {
       const { studyId, habitId } = req.params;
       const { name } = req.body;
 
-      // if (!name || name.trim() === "") {
-      //   return res.status(400).json({
-      //     success: false,
-      //     massage: '잘못된 요청입니다.',
-      //     errors: '습관 이름은 필수 입력값입니다.',
-      //   });
-      // }
+      if (!name || name.trim() === "") {
+        return res.status(400).json({
+          success: false,
+          massage: '잘못된 요청입니다.',
+          errors: '습관 이름은 필수 입력값입니다.',
+        });
+      }
 
       const updatedHabit = await prisma.habit.update({
         where: { 

--- a/src/controllers/HabitWriteController.js
+++ b/src/controllers/HabitWriteController.js
@@ -140,3 +140,62 @@ export const toggleHabit = async (req, res) => {
     });
   }
 };
+
+// 습관 수정
+export const editHabit = async (req, res) => {
+    try {
+      const { studyId, habitId} = req.params;
+      const { name } = req.body;
+
+      if (!name || name.trim() === "") {
+        return res.status(400).json({
+          success: false,
+          massage: '잘못된 요청입니다.',
+          errors: '이름은 필수 입력값입니다.',
+        });
+      }
+
+      const habit = await prisma.habit.findFirst({
+        where: {
+          id: Number(habitId),
+          studyId: Number(studyId),
+          endDate: null,
+        },
+      });
+
+      if (!habit) {
+        return res.status(404).json({
+          success: false,
+          message: '수정할 습관을 찾을 수 없습니다.',
+          errors: [],
+        });
+      }
+
+      const updateHabit = await prisma.habit.update({
+        where: { id: Number(habitId) },
+        data: { name: name.trim()},
+      })
+
+      return res.status(200).json({
+        success:true,
+        message: '습관이 수정되었습니다.',
+        data: { habit: updateHabit }
+      });
+
+    } catch (error) {
+    console.error(error);
+    return res.status(500).json({
+      success: false,
+      message: '서버 내부 오류가 발생했습니다.',
+      errors: [],
+    });
+  }
+};
+
+export const deleteHabit = async (req, res) => {
+  try {
+
+  } catch (error) {
+
+  }
+};

--- a/src/routes/HabitRoutes.js
+++ b/src/routes/HabitRoutes.js
@@ -2,6 +2,8 @@ import express from 'express';
 import {
   createHabit,
   toggleHabit,
+  editHabit,
+  deleteHabit,
 } from '../controllers/HabitWriteController.js';
 import {
   getTodayHabits,
@@ -13,6 +15,8 @@ const router = express.Router();
 router.get('/:studyId/today', getTodayHabits);
 router.post('/:studyId', createHabit);
 router.patch('/:studyId/:habitId/today', toggleHabit);
+router.patch('/:studyId/:habitId', editHabit);
+router.delete('/:studyId/:habitId', deleteHabit)
 
 router.get('/:studyId/weekly', getWeekHabits);
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #49 



## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

- 습관 목록 모달에서 수정, 삭제 기능을 구현했습니다.

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 수정 : 습관 이름 수정 후 적용
- 삭제 : 데이터를 완전히 삭제하는 것이 아닌 endDate를 현재 시간으로 설정하여 종료 처리함.
- 예외처리 (404, 200, 500 등)


## 📷 스크린샷 (선택사항)

> 필요한 경우, 스크린샷을 남겨주세요.

- **수정 전** 
<img width="495" height="62" alt="sadasdfsdf" src="https://github.com/user-attachments/assets/672f6f1b-cedd-47df-8741-f80ed4897acd" />

- **수정 후**
<img width="510" height="58" alt="sadasdfsdf" src="https://github.com/user-attachments/assets/2504c3e6-5017-4beb-bddd-03f30bde5bf9" />

- **삭제 시** 
<img width="509" height="284" alt="success true," src="https://github.com/user-attachments/assets/83cef9b5-7c8b-428a-a2cb-7ed6643a44b3" />

- **디비버에서 endDate 확인**
<img width="421" height="35" alt="image" src="https://github.com/user-attachments/assets/b782b43b-e754-43b2-85d1-26a7ed51379e" />

