### PR TITLE
[Refactor] 오늘의 습관 조회 조건 개선 및 생성자 정보 추가

### DIFF
--- a/src/controllers/HabitReadController.js
+++ b/src/controllers/HabitReadController.js
@@ -14,6 +14,7 @@ export const getTodayHabits = async (req, res) => {
       },
       select: {
         title: true,
+        nickname: true,
       },
     });
 

--- a/src/controllers/HabitReadController.js
+++ b/src/controllers/HabitReadController.js
@@ -17,6 +17,7 @@ export const getTodayHabits = async (req, res) => {
       },
     });
 
+    // 스터디 찾기
     if (!study) {
       return res.status(404).json({
         success: false,
@@ -28,6 +29,10 @@ export const getTodayHabits = async (req, res) => {
     const habits = await prisma.habit.findMany({
       where: {
         studyId: Number(studyId),
+        startDate: {
+          lte: end,
+        },
+        endDate: null,
       },
       include: {
         records: {
@@ -87,6 +92,7 @@ export const getWeekHabits = async (req, res) => {
       },
     });
 
+    // 스터디 찾기
     if (!study) {
       return res.status(404).json({
         success: false,

--- a/src/lib/DateRange.js
+++ b/src/lib/DateRange.js
@@ -1,4 +1,4 @@
-export const getDateRange = (date) => {
+export const getDateRange = (date = new Date()) => {
   const start = new Date(date);
   start.setHours(0, 0, 0, 0);
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #50 



## 📒 설명

> 오늘의 습관 조회 API에서 조회 조건을 보완하고, 스터디 생성자 정보를 함께 반환하도록 개선했습니다.



## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 오늘의 습관 조회 시 endDate 조건을 반영하여 종료된 습관이 조회되지 않도록 수정
- DateRange 유틸의 기본값을 new Date()로 설정하여 호출 시 일관된 날짜 기준 사용
- 일일 습관 조회 API 응답에 스터디 생성자(nickname) 정보 추가

## 📦 참고사항 (선택사항)

> ex: OOO 패키지를 적용했습니다! `npm install ~~~ `

- 일일 습관 조회 API 응답에 스터디 생성자(nickname) 정보 추가하여 추후 스터디명 조회에서 생성자"의" 스터디명으로 수정하겠습니다.