### PR TITLE
[Feat] 집중 완료 성공 시, 집중 완료 성공한 집중 목표 시간으로 타이머 재생성

### DIFF
--- a/src/controllers/timerController.js
+++ b/src/controllers/timerController.js
@@ -370,10 +370,11 @@ export const updateComplete = async (req, res) => {
       return;
     }
     if (timer.status === 'CANCELED') {
-      return res.status(204).json({
+      res.status(204).json({
         success: false,
         message: '타이머가 진행중이지 않습니다.',
       });
+      return;
     }
 
     // 서버 현재 시간과 DB에 저장된 경과 시간을 비교 검증
@@ -383,7 +384,7 @@ export const updateComplete = async (req, res) => {
     if (elapsedTime < timer.targetDuration) {
       res.status(400).json({
         success: false,
-        message: '집중 목표 시간을 아직 달성하지 못했습니다.',
+        message: '아직 집중 목표 시간을 달성하지 못했습니다.',
         data: {
           targetDuration: timer.targetDuration,
           elapsedTime,
@@ -421,6 +422,7 @@ export const updateComplete = async (req, res) => {
         prisma.timer.create({
           data: {
             studyId,
+            targetDuration: timer.targetDuration,
           },
         }),
       ]);


### PR DESCRIPTION
## 🔥 Related Issues

- close #56 



## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

집중 완료 성공 시, 기존 25분으로 타이머가 생성되던 것을 집중 완료한 집중 목표 시간으로 타이머가 생성될 수 있도록 구현

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 집중 완료 성공 시, 타이머를 재생성할때 집중 목표 시간 설정해서 생성


## 📷 스크린샷 

### 1. 집중 목표 시간 설정
<img width="793" height="50" alt="9_BE_집중목표시간설정_DB" src="https://github.com/user-attachments/assets/3384bcfd-97d3-4e39-9077-e02afc58fa9b" />


### 2. 집중 완료 성공 시, 완료한 집중 목표 시간으로 타이머 재생성
<img width="926" height="64" alt="9_2_BE_집중완료시_타이머_초기화" src="https://github.com/user-attachments/assets/7583d563-24fa-4b8b-ab36-350413c23653" />




