### PR TITLE
[Feat] 주간 습관 조회 필터링 로직 추가

### DIFF
--- a/src/controllers/HabitReadController.js
+++ b/src/controllers/HabitReadController.js
@@ -140,7 +140,16 @@ export const getWeekHabits = async (req, res) => {
       },
     });
 
-    const weeklyHabits = habits.map((h) => ({
+    const filterHabits = habits.filter((h) => {
+      const hasTrueThisWeek = h.records.some((r) => r.isCompleted === true);
+      if (h.endDate === null) return true;
+
+      if (hasTrueThisWeek) return true;
+
+      return false;
+    });
+
+    const weeklyHabits = filterHabits.map((h) => ({
       id: h.id,
       name: h.name,
       records: h.records,


### PR DESCRIPTION
## 🔥 Related Issues

- close #61 



## 📒 설명

> 주간 습관 조회 시 노출 대상 기준을 반영해 필터링 로직을 추가했습니다.



## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 주간 습관 조회 결과에 대해 진행 중인 습관(endDate === null)은 포함되도록 처리했습니다.
- 종료된 습관 중 이번 주 isCompleted === true 기록이 있는 경우만 포함되도록 필터링 로직을 추가했습니다.
- 종료됐고 이번 주 true 기록이 없는 습관은 응답에서 제외되도록 반영했습니다.
- 주간 조회 응답 데이터가 의도한 기준대로 내려오는지 확인했습니다.

## 📷 스크린샷 (선택사항)

> 필요한 경우, 스크린샷을 남겨주세요.



## 📦 참고사항 (선택사항)

> ex: OOO 패키지를 적용했습니다! `npm install ~~~ `

- 주간 조회 노출 기준은 현재 진행 중인 습관 또는 이번 주 완료 기록이 있는 습관으로 정의했습니다.