### PR TITLE
[Fix]스터디 생성,수정 부분에서 공통 닉네임과 제목이 들어갈 시 생성 불가 

### DIFF
--- a/prisma/migrations/20260422021839_add_unique_nickname_title/migration.sql
+++ b/prisma/migrations/20260422021839_add_unique_nickname_title/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[nickname,title]` on the table `studies` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "studies_nickname_title_key" ON "studies"("nickname", "title");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Study {
   @@index([createdAt])
   @@index([title])
   @@index([nickname])
+  @@unique([nickname, title])
   @@map("studies")
 }
 

--- a/src/controllers/studyController.js
+++ b/src/controllers/studyController.js
@@ -334,6 +334,12 @@ export const createStudy = async (req, res) => {
       data: result,
     });
   } catch (error) {
+    if (error.code === 'P2002') {
+      return res.status(400).json({
+        success: false,
+        message: '이미 같은 닉네임과 제목이 존재합니다.',
+      });
+    }
     return res.status(500).json({
       success: false,
       message: '서버 내부 오류가 발생했습니다.',
@@ -414,7 +420,12 @@ export const updateStudy = async (req, res) => {
       data: updatedStudy,
     });
   } catch (error) {
-    console.error(error);
+    if (error.code === 'P2002') {
+      return res.status(400).json({
+        success: false,
+        message: '이미 같은 닉네임과 제목이 존재합니다.',
+      });
+    }
 
     return res.status(500).json({
       success: false,


### PR DESCRIPTION
## 🔥 Related Issues

- close #64 



## 📒 설명

> 스터디 생성,수정 부분에서 공통 닉네임과 제목이 들어갈 시 생성 안되도록 수



## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 스터디 생성,수정 부분에서 공통 닉네임과 제목이 들어갈 시 생 안되도록 수정
-


## 📷 스크린샷 (선택사항)

> <img width="1574" height="787" alt="image" src="https://github.com/user-attachments/assets/bbdef4c4-c6a7-4097-a83f-29cf467da23a" />



## 📦 참고사항

> npx prisma migrate dev --name add_unique_nickname_title 적용 했습니다
(nickname과 title을 스키마에서 의도적으로 같으면 생성못하도록 설정)

pull 받고나면 npx prisma generate 스키마 수정으로 해야함!!

📋 PR 기본 정보
**프로젝트:  초급
**주차: 11주차
**PR 요약: 스터디 생성, 수정 부분 공통 닉네임과 제목이 들어갈 시 생성 불가

🛠️ 구현 내용
스터디 생성, 수정 부분 공통 닉네임과 제목이 들어갈 시 생성 불가

🔍 코드리뷰 요청 사항
코드리뷰 멘토에게 피드백 받고 싶은 부분을 구체적으로 작성해 주세요.
파일명, 라인 번호, 함수명 등을 함께 적어주시면 멘토가 집중해서 볼 수 있습니다.

요청 1
파일/위치: src/controllers/studyController.js

요청 내용:  unique로 제약 조건을 거는 방법 밖에 없는지 궁금합니다

고민한 점: 중복 생성을 못하게 막고 싶어서 찾아보았는데 닉네임만 중복되도 안되거나 제목만 같아도 생성안되는 부분을 고민하다가 둘다 같을때 생성이 안되게 하는것이 괜찮은지 고민하고 있습니다.