### PR TITLE
[Feat] 집중 로그 조회 페이징 처리 및 응답 포맷 변경

### DIFF
--- a/src/controllers/LogsController.js
+++ b/src/controllers/LogsController.js
@@ -4,6 +4,8 @@ import { getDateRange } from '../lib/DateRange.js'
 export const getStudyLogs = async (req, res) => {
   try {
     const { studyId } = req.params;
+    const page = parseInt(req.query.page) || 1;
+    const pageSize = parseInt(req.query.pageSize) || 5;
 
     if (isNaN(Number(studyId))) {
       return res.status(400).json({
@@ -14,37 +16,47 @@ export const getStudyLogs = async (req, res) => {
     }
 
     const { date } = req.query;
-
-    const study = await prisma.study.findUnique({
-      where: { id: Number(studyId)},
-    })
-    if (!study) {
-      return res.status(404).json({
-        "success": false,
-        "message": "스터디를 찾을 수 없습니다.",
-        "errors": [],
-      });
-    }
     const { start, end } = getDateRange(date);
+
+    const totalCount = await prisma.pointLog.count({
+      where: {
+        studyId: Number(studyId),
+        createdAt: {
+          gte: start,
+          lte: end
+        }
+      }
+    })
+
+    const totalPages = Math.ceil(totalCount / pageSize);
+    const skip = (page - 1 ) * pageSize;
 
     const logs = await prisma.pointLog.findMany({
       where: {
         studyId: Number(studyId),
         createdAt: {
           gte: start,
-          lte: end,
+          lte: end
         }
       },
-      orderBy: {
-        createdAt: "asc",
-      }
-    })
+      orderBy: {createdAt: "asc"},
+      skip,
+      take: pageSize
+    });
 
     return res.status(200).json({
       "success": true,
       "message": "요청이 정상적으로 처리되었습니다.",
-      "data": logs,
-    })
+      "data": {
+        logs: logs,
+        pagination: {
+          currentPage: page,
+          pageSize: pageSize,
+          totalCount: totalCount,
+          totalPages: totalPages
+        }
+      }
+    });
   } catch (error) {
     console.error(error);
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #68 


---


## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

- 집중 로그 페이징 처리
- 응답 포맷을 변경했습니다.


---


## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 원하는 구간의 데이터만 조회할 수 있도록 로직을 추가했습니다.
- prisma의 skip과  take 옵션을 사용해 DB에서 페이징 처리합니다.
- data 필드에 배열로 담기던 로그 데이터를 객체 형태로 감싸고, 페이지네이션 데이터를 추가했습니다.


---


## 📷 스크린샷 (선택사항)

> 필요한 경우, 스크린샷을 남겨주세요.

- GET 요청 시
<img width="668" height="523" alt="image" src="https://github.com/user-attachments/assets/a6bedbde-fe05-47da-8e43-e53131760ec6" />
포스트맨을 통해 해당 경로로 데이터가 정상 호출됨을 확인