### PR TITLE
[Feat] 포인트, 집중시간 하루 총합으로 수정

### DIFF
--- a/src/controllers/LogsController.js
+++ b/src/controllers/LogsController.js
@@ -18,15 +18,28 @@ export const getStudyLogs = async (req, res) => {
     const { date } = req.query;
     const { start, end } = getDateRange(date);
 
-    const totalCount = await prisma.pointLog.count({
-      where: {
-        studyId: Number(studyId),
-        createdAt: {
-          gte: start,
-          lte: end
+    const [totalCount, totals] = await Promise.all([
+      prisma.pointLog.count({
+        where: { 
+          studyId: Number(studyId), 
+          createdAt: { 
+            gte: start,
+            lte: end
+          }}
+      }),
+      prisma.pointLog.aggregate({
+        where: { 
+          studyId: Number(studyId),
+          createdAt: {
+            gte: start,
+            lte: end 
+          }},
+        _sum: {
+          points: true,
+          focusDuration: true
         }
-      }
-    })
+      })
+    ]);
 
     const totalPages = Math.ceil(totalCount / pageSize);
     const skip = (page - 1 ) * pageSize;
@@ -49,6 +62,11 @@ export const getStudyLogs = async (req, res) => {
       "message": "요청이 정상적으로 처리되었습니다.",
       "data": {
         logs: logs,
+        totalStats: {
+          totalPoint: totals._sum.points || 0,
+          totalFocus: totals._sum.focusDuration || 0
+        },
+
         pagination: {
           currentPage: page,
           pageSize: pageSize,


### PR DESCRIPTION
## 🔥 Related Issues

- close #70 

---

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

- 페이지네이션 기능 추가로 인해 해당 페이지 데이터만 합산되어 총합으로 표시되는 오류를 수정했습니다.
- 특정 날짜에 대한 전체 합계를 기존 API를 활용하여 응답에 포함시킵니다.


---


## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- _sum 기능을 사용하여 조회 날짜 전체 포인트와 집중 시간의 합계를 구하는 로직을 추가했습니다.
- promise.all을 사용하여 API 응답 속도를 최적화 했습니다.


---


## 📷 스크린샷 (선택사항)

> 필요한 경우, 스크린샷을 남겨주세요.

- 포스트맨 GET 요청 시
<img width="673" height="555" alt="image" src="https://github.com/user-attachments/assets/f7cf1e9b-1281-4499-9955-288b3acd8c4a" />

<img width="669" height="397" alt="image" src="https://github.com/user-attachments/assets/956ab661-e25d-46a5-b29b-d1c73f5186ee" />
